### PR TITLE
Rename main heading to Potepan Tasks and remove tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,7 @@
   <body>
     <div class="app-shell">
       <header class="app-header">
-        <p class="eyebrow">Design your day</p>
-        <h1 class="app-title">Daydream Tasks</h1>
+        <h1 class="app-title">Potepan Tasks</h1>
         <p class="app-subtitle">
           ひらめきや予定を、やさしい色彩の空間で整理しましょう。シンプルだけど
           少し特別な、そんなToDoリストです。


### PR DESCRIPTION
## Summary
- update the main header text to read "Potepan Tasks"
- remove the "Design your day" tagline from the hero header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceaaf7405c832c91608d3f280865ac